### PR TITLE
- remove RevokeURL field from individual providers.

### DIFF
--- a/internal/identity/gitlab.go
+++ b/internal/identity/gitlab.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 
 	oidc "github.com/coreos/go-oidc"
 	"golang.org/x/oauth2"
@@ -25,7 +24,6 @@ const (
 // GitLabProvider is an implementation of the OAuth Provider
 type GitLabProvider struct {
 	*Provider
-	RevokeURL string `json:"revocation_endpoint"`
 }
 
 // NewGitLabProvider returns a new GitLabProvider.
@@ -99,18 +97,4 @@ func (p *GitLabProvider) UserGroups(ctx context.Context, s *sessions.State) ([]s
 	}
 
 	return groups, nil
-}
-
-// Revoke attempts to revoke session access via revocation endpoint
-// https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#revoking-a-personal-access-token
-func (p *GitLabProvider) Revoke(ctx context.Context, token *oauth2.Token) error {
-	params := url.Values{}
-	params.Add("access_token", token.AccessToken)
-
-	err := httputil.Client(ctx, http.MethodPost, p.RevokeURL, version.UserAgent(), nil, params, nil)
-	if err != nil && err != httputil.ErrTokenRevoked {
-		return err
-	}
-
-	return nil
 }

--- a/internal/identity/google.go
+++ b/internal/identity/google.go
@@ -5,18 +5,14 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/url"
 
 	oidc "github.com/coreos/go-oidc"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	admin "google.golang.org/api/admin/directory/v1"
 
-	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/sessions"
-	"github.com/pomerium/pomerium/internal/version"
 )
 
 const defaultGoogleProviderURL = "https://accounts.google.com"
@@ -24,8 +20,6 @@ const defaultGoogleProviderURL = "https://accounts.google.com"
 // GoogleProvider is an implementation of the Provider interface.
 type GoogleProvider struct {
 	*Provider
-
-	RevokeURL string `json:"revocation_endpoint"`
 
 	apiClient *admin.Service
 }
@@ -93,19 +87,6 @@ func NewGoogleProvider(p *Provider) (*GoogleProvider, error) {
 	}
 
 	return gp, nil
-}
-
-// Revoke revokes the access token a given session state.
-//
-// https://developers.google.com/identity/protocols/OAuth2WebServer#tokenrevoke
-func (p *GoogleProvider) Revoke(ctx context.Context, token *oauth2.Token) error {
-	params := url.Values{}
-	params.Add("token", token.AccessToken)
-	err := httputil.Client(ctx, http.MethodPost, p.RevokeURL, version.UserAgent(), nil, params, nil)
-	if err != nil && err != httputil.ErrTokenRevoked {
-		return err
-	}
-	return nil
 }
 
 // GetSignInURL returns a URL to OAuth 2.0 provider's consent page that asks for permissions for

--- a/internal/identity/microsoft.go
+++ b/internal/identity/microsoft.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
 
 	oidc "github.com/coreos/go-oidc"
@@ -26,8 +25,6 @@ const defaultAzureGroupURL = "https://graph.microsoft.com/v1.0/me/memberOf"
 // AzureProvider is an implementation of the Provider interface
 type AzureProvider struct {
 	*Provider
-	// non-standard oidc fields
-	RevokeURL string `json:"end_session_endpoint"`
 }
 
 // NewAzureProvider returns a new AzureProvider and sets the provider url endpoints.
@@ -62,18 +59,6 @@ func NewAzureProvider(p *Provider) (*AzureProvider, error) {
 	p.UserGroupFn = azureProvider.UserGroups
 
 	return azureProvider, nil
-}
-
-// Revoke revokes the access token a given session state.
-// https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc#send-a-sign-out-request
-func (p *AzureProvider) Revoke(ctx context.Context, token *oauth2.Token) error {
-	params := url.Values{}
-	params.Add("token", token.AccessToken)
-	err := httputil.Client(ctx, http.MethodPost, p.RevokeURL, version.UserAgent(), nil, params, nil)
-	if err != nil && err != httputil.ErrTokenRevoked {
-		return err
-	}
-	return nil
 }
 
 // GetSignInURL returns the sign in url with typical oauth parameters

--- a/internal/identity/okta.go
+++ b/internal/identity/okta.go
@@ -22,8 +22,7 @@ import (
 type OktaProvider struct {
 	*Provider
 
-	RevokeURL string `json:"revocation_endpoint"`
-	userAPI   *url.URL
+	userAPI *url.URL
 }
 
 // NewOktaProvider creates a new instance of Okta as an identity provider.
@@ -49,7 +48,6 @@ func NewOktaProvider(p *Provider) (*OktaProvider, error) {
 		Scopes:       p.Scopes,
 	}
 
-	// okta supports a revocation endpoint
 	oktaProvider := OktaProvider{Provider: p}
 	if err := p.provider.Claims(&oktaProvider); err != nil {
 		return nil, err
@@ -68,19 +66,6 @@ func NewOktaProvider(p *Provider) (*OktaProvider, error) {
 	}
 
 	return &oktaProvider, nil
-}
-
-// Revoke revokes the access token a given session state.
-// https://developer.okta.com/docs/api/resources/oidc#revoke
-func (p *OktaProvider) Revoke(ctx context.Context, token *oauth2.Token) error {
-	params := url.Values{}
-	params.Add("token", token.AccessToken)
-	params.Add("token_type_hint", "refresh_token")
-	err := httputil.Client(ctx, http.MethodPost, p.RevokeURL, version.UserAgent(), nil, params, nil)
-	if err != nil && err != httputil.ErrTokenRevoked {
-		return err
-	}
-	return nil
 }
 
 // UserGroups fetches the groups of which the user is a member


### PR DESCRIPTION
- Remove Revoke function from providers that use the RFC method.
- Add "client auth" for okta and one-login

Signed-off-by: Bobby DeSimone <bobbydesimone@gmail.com>

## Summary
<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues
<!-- For example...
Fixes #159 
-->


**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] ready for review
